### PR TITLE
Feature: first not attr

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,12 +6,12 @@ repos:
     hooks:
       - id: black
         name: black
-        entry: black pretty_match tests
+        entry: poetry run black pretty_match tests
         language: python
         types: [python]
 
       - id: isort
         name: isort
-        entry: isort pretty_match tests
+        entry: poetry run isort pretty_match tests
         language: python
         types: [python]

--- a/examples/main.py
+++ b/examples/main.py
@@ -1,7 +1,7 @@
 from typing import Optional
 
 from pretty_match import results
-from pretty_match.attrs import AttrIsNone, FirstNoneAttr
+from pretty_match.attrs import AttrIsNot, AttrIsNone, FirstNotAttr, FirstNoneAttr
 from pretty_match.comparable import Number
 
 
@@ -24,6 +24,10 @@ class Query:
         self.token = token
         self.start = start
         self.end = end
+
+    @property
+    def is_valid(self) -> bool:
+        return False
 
 
 def process_transaction(user: User, product: Product) -> None:
@@ -50,3 +54,11 @@ if __name__ == "__main__":
             print("start required!")
         case AttrIsNone(name="end"):
             print("end required!")
+
+    query = Query(token="test", start=None, end=2)
+    attrs_to_check = ["token", "is_valid"]
+    match FirstNotAttr(*attrs_to_check, instance=query):
+        case AttrIsNot(name="token"):
+            print("token required!")
+        case AttrIsNot(name="is_valid"):
+            print("Query is not valid!")

--- a/pretty_match/attrs.py
+++ b/pretty_match/attrs.py
@@ -17,10 +17,10 @@ class AttrIsNot:
         self.name = name
 
     def __str__(self):
-        return f"<FirstNotAttr: {self.name}>"
+        return f"<AttrIsNot: {self.name}>"
 
     def __repr__(self):
-        return f"<FirstNotAttr: {self.name}>"
+        return f"<AttrIsNot: {self.name}>"
 
     def __eq__(self, other):
         return other.name == self.name

--- a/pretty_match/attrs.py
+++ b/pretty_match/attrs.py
@@ -12,7 +12,27 @@ class AttrIsNone:
         return other.name == self.name
 
 
+class AttrIsNot:
+    def __init__(self, name: str):
+        self.name = name
+
+    def __str__(self):
+        return f"<FirstNotAttr: {self.name}>"
+
+    def __repr__(self):
+        return f"<FirstNotAttr: {self.name}>"
+
+    def __eq__(self, other):
+        return other.name == self.name
+
+
 def FirstNoneAttr(*attr_names, instance):
     for attr_name in attr_names:
         if getattr(instance, attr_name) is None:
+            return AttrIsNone(attr_name)
+
+
+def FirstNotAttr(*attr_names, instance):
+    for attr_name in attr_names:
+        if not getattr(instance, attr_name):
             return AttrIsNone(attr_name)


### PR DESCRIPTION
## Description
This PR adds ability to use `is not` for attrs  check

```python
class Query:
    def __init__(self, token: Optional[str], start: Optional[int], end: Optional[int]):
        self.token = token
        self.start = start
        self.end = end

    @property
    def is_valid(self) -> bool:
        return False

  query = Query(token="test", start=None, end=2)
  attrs_to_check = ["token", "is_valid"]
  match FirstNotAttr(*attrs_to_check, instance=query):
      case AttrIsNot(name="token"):
          print("token required!")
      case AttrIsNot(name="is_valid"):
          print("Query is not valid!")


```